### PR TITLE
Debump and bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ilp-cli"
-version = "1.0.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "http",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ilp-node"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "approx",
  "base64 0.11.0",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "interledger"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "interledger-api",
  "interledger-btp",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-api"
-version = "1.0.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-btp"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-ccp"
-version = "1.0.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-errors"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "http",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-http"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-ildcp"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-packet"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "byteorder",
  "bytes 0.5.6",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-rates"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "futures 0.3.13",
  "interledger-errors",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-router"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "interledger-errors",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-service"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-service-util"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-settlement"
-version = "1.0.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-spsp"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.11.0",
  "bytes 0.5.6",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-store"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-stream"
-version = "1.0.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "interledger"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "interledger-api",
  "interledger-btp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-store"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "ilp-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "approx",
  "base64 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-settlement"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "interledger-stream"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.11.0",

--- a/crates/ilp-cli/Cargo.toml
+++ b/crates/ilp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilp-cli"
-version = "1.0.0"
+version = "0.3.0"
 authors = ["Ben Striegel <bstriegel@ripple.com>"]
 description = "Interledger.rs Command-Line Interface"
 license = "Apache-2.0"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilp-node"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Interledger node (sender, connector, receiver bundle)"
 license = "Apache-2.0"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -37,7 +37,7 @@ required-features = ["redis"]
 vergen = { version = "4.2" }
 
 [dependencies]
-interledger = { path = "../interledger", version = "^0.6.0", default-features = false, features = ["node"] }
+interledger = { path = "../interledger", version = "^0.7.0", default-features = false, features = ["node"] }
 
 bytes = { package = "bytes", version = "0.5" }
 cfg-if = { version = "0.1.10", default-features = false }

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ilp-node"
-version = "1.0.0"
+version = "0.6.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Interledger node (sender, connector, receiver bundle)"
 license = "Apache-2.0"
@@ -37,7 +37,7 @@ required-features = ["redis"]
 vergen = { version = "4.2" }
 
 [dependencies]
-interledger = { path = "../interledger", version = "1.0.0", default-features = false, features = ["node"] }
+interledger = { path = "../interledger", version = "^0.6.0", default-features = false, features = ["node"] }
 
 bytes = { package = "bytes", version = "0.5" }
 cfg-if = { version = "0.1.10", default-features = false }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-api"
-version = "1.0.0"
+version = "0.3.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "API for managing an Interledger node"
 license = "Apache-2.0"
@@ -8,19 +8,19 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-http = { path = "../interledger-http", version = "1.0.0", default-features = false }
-interledger-ildcp = { path = "../interledger-ildcp", version = "1.0.0", default-features = false }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
-interledger-router = { path = "../interledger-router", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
-interledger-service-util = { path = "../interledger-service-util", version = "1.0.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "1.0.0", default-features = false }
-interledger-spsp = { path = "../interledger-spsp", version = "1.0.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "1.0.0", default-features = false }
-interledger-ccp = { path = "../interledger-ccp", version = "1.0.0", default-features = false }
-interledger-btp = { path = "../interledger-btp", version = "1.0.0", default-features = false }
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false, features = ["warp_errors"] }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
+interledger-ildcp = { path = "../interledger-ildcp", version = "^0.4.0", default-features = false }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
+interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
+interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
+interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
+interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", default-features = false }
+interledger-btp = { path = "../interledger-btp", version = "^0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["warp_errors"] }
 
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3.7", default-features = false }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -15,7 +15,7 @@ interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default
 interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.4.0", default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.5.0", default-features = false }
 interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", default-features = false }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -17,7 +17,7 @@ interledger-service = { path = "../interledger-service", version = "^0.4.0", def
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.5.0", default-features = false }
 interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", default-features = false }
 interledger-btp = { path = "../interledger-btp", version = "^0.4.0", default-features = false }
 interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["warp_errors"] }

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-btp"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Bilateral Transfer Protocol (BTP) client and server services for Interledger.rs"
 license = "Apache-2.0"
@@ -11,9 +11,9 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 strict = ["interledger-packet/strict"]
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 bytes = { version = "0.5" }
 byteorder = { version = "1.3.2" }

--- a/crates/interledger-ccp/Cargo.toml
+++ b/crates/interledger-ccp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-ccp"
-version = "1.0.0"
+version = "0.3.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Implementation of the Interledger Dynamic Configuration Protocol (ILDCP)"
 license = "Apache-2.0"
@@ -8,9 +8,9 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 bytes = { version = "0.5" }
 byteorder = { version = "1.3.2" }

--- a/crates/interledger-errors/Cargo.toml
+++ b/crates/interledger-errors/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "interledger-errors"
-version = "1.0.0"
+version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 
 once_cell = { version = "1.3.1", default-features = false }
 thiserror = { version = "1.0.10", default-features = false }

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-http"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "HTTP client and server services for Interledger.rs"
 license = "Apache-2.0"
@@ -8,9 +8,9 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3.7", default-features = false }

--- a/crates/interledger-ildcp/Cargo.toml
+++ b/crates/interledger-ildcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-ildcp"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Implementation of the Interledger Dynamic Configuration Protocol (ILDCP)"
 license = "Apache-2.0"
@@ -8,8 +8,8 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 bytes = { version = "0.5" }
 byteorder = { version = "1.3.2", default-features = false }

--- a/crates/interledger-packet/Cargo.toml
+++ b/crates/interledger-packet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-packet"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Interledger packet serialization/deserialization"
 license = "Apache-2.0"

--- a/crates/interledger-rates/Cargo.toml
+++ b/crates/interledger-rates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-rates"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Exchange rate utilities"
 license = "Apache-2.0"
@@ -8,8 +8,7 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0" }
-
+interledger-errors = { path = "../interledger-errors", version = "0.1.0" }
 futures = { version = "0.3.7", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 once_cell = { version = "1.3.1", default-features = false }

--- a/crates/interledger-router/Cargo.toml
+++ b/crates/interledger-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-router"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Router for Interledger requests"
 license = "Apache-2.0"
@@ -8,8 +8,8 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 parking_lot = { version = "0.10.0", default-features = false }
@@ -19,4 +19,4 @@ async-trait = { version = "0.1.22", default-features = false }
 [dev-dependencies]
 once_cell = { version = "1.3.1", default-features = false }
 tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "macros"]}
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-service-util"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Small, commonly used Interledger services that don't really fit anywhere else"
 license = "Apache-2.0"
@@ -8,11 +8,11 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "1.0.0", default-features = false, features = ["settlement_api"] }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false, features = ["settlement_api"] }
 
 bytes = { version = "0.5", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -12,7 +12,7 @@ interledger-errors = { path = "../interledger-errors", version = "^0.1.0", defau
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false, features = ["settlement_api"] }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.4.0", default-features = false, features = ["settlement_api"] }
 
 bytes = { version = "0.5", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-service"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "The core abstraction for the Interledger.rs implementation"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ default = []
 trace = ["tracing-futures"]
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 
 futures = { version = "0.3.7", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-settlement"
-version = "1.0.0"
+version = "0.3.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Settlement-related components for Interledger.rs"
 license = "Apache-2.0"
@@ -8,10 +8,10 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false, features = ["redis_errors"] }
-interledger-http = { path = "../interledger-http", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
+interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3.7", default-features = false }

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-settlement"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Settlement-related components for Interledger.rs"
 license = "Apache-2.0"

--- a/crates/interledger-spsp/Cargo.toml
+++ b/crates/interledger-spsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-spsp"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Client and server implementations of the Simple Payment Setup Protocol (SPSP)"
 license = "Apache-2.0"
@@ -8,10 +8,10 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", features = ["serde"], default-features = false }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "1.0.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", features = ["serde"], default-features = false }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
 
 base64 = { version = "0.11.0", default-features = false }
 bytes = { version = "0.5", default-features = false }

--- a/crates/interledger-spsp/Cargo.toml
+++ b/crates/interledger-spsp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", features = ["serde"], default-features = false }
 interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.5.0", default-features = false }
 
 base64 = { version = "0.11.0", default-features = false }
 bytes = { version = "0.5", default-features = false }

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-store"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Data stores for Interledger.rs"
 license = "Apache-2.0"
@@ -21,18 +21,18 @@ path = "tests/redis/redis_tests.rs"
 required-features = ["redis"]
 
 [dependencies]
-interledger-api = { path = "../interledger-api", version = "1.0.0", default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-btp = { path = "../interledger-btp", version = "1.0.0", default-features = false }
-interledger-ccp = { path = "../interledger-ccp", version = "1.0.0", default-features = false }
-interledger-http = { path = "../interledger-http", version = "1.0.0", default-features = false }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
-interledger-router = { path = "../interledger-router", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
-interledger-service-util = { path = "../interledger-service-util", version = "1.0.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "1.0.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "1.0.0", default-features = false }
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false, features = ["redis_errors"] }
+interledger-api = { path = "../interledger-api", version = "^0.3.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-btp = { path = "../interledger-btp", version = "^0.4.0", default-features = false }
+interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", default-features = false }
+interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
+interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
+interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
 
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3.7", default-features = false }

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -30,7 +30,7 @@ interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default
 interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.4.0", default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.5.0", default-features = false }
 interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
 

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -31,7 +31,7 @@ interledger-router = { path = "../interledger-router", version = "^0.4.0", defau
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.5.0", default-features = false }
 interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
 
 bytes = { version = "0.5", default-features = false }

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-store"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Data stores for Interledger.rs"
 license = "Apache-2.0"

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-stream"
-version = "1.0.0"
+version = "0.4.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Client and server implementations of the STREAM transport protocol"
 license = "Apache-2.0"
@@ -12,12 +12,12 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 strict = ["interledger-packet/strict"]
 # Only applicable for roundtripping in fuzzing
 # Deliberate error for valid replacement of data, such as `saturating_read_var_uint`.
-roundtrip-only = ["strict"] 
+roundtrip-only = ["strict"]
 
 [dependencies]
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false, features = ["serde"] }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false, features = ["serde"] }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 
 base64 = { version = "0.11.0", default-features = false, features = ["std"] }
 bytes = { version = "0.5" }
@@ -35,9 +35,9 @@ pin-project = { version = "0.4.7", default-features = false }
 thiserror = { version = "1.0.10", default-features = false }
 
 [dev-dependencies]
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-router = { path = "../interledger-router", version = "1.0.0", default-features = false }
-interledger-service-util = { path = "../interledger-service-util", version = "1.0.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
+interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", default-features = false }
 hex-literal = "0.3"
 parking_lot = { version = "0.10.0", default-features = false }
 

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger-stream"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Client and server implementations of the STREAM transport protocol"
 license = "Apache-2.0"

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -53,7 +53,7 @@ interledger-service = { path = "../interledger-service", version = "^0.4.0", def
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", optional = true, default-features = false }
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", optional = true, default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "^0.4.0", optional = true, default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.5.0", optional = true, default-features = false }
 interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }
 
 [badges]

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger"
-version = "1.0.0"
+version = "0.6.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Interledger client library"
 license = "Apache-2.0"
@@ -40,21 +40,21 @@ trace = ["interledger-service/trace"]
 redis = ["interledger-store/redis"]
 
 [dependencies]
-interledger-api = { path = "../interledger-api", version = "1.0.0", optional = true, default-features = false }
-interledger-btp = { path = "../interledger-btp", version = "1.0.0", optional = true, default-features = false }
-interledger-ccp = { path = "../interledger-ccp", version = "1.0.0", optional = true, default-features = false }
-interledger-http = { path = "../interledger-http", version = "1.0.0", optional = true, default-features = false }
-interledger-ildcp = { path = "../interledger-ildcp", version = "1.0.0", optional = true, default-features = false }
-interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
-interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
-interledger-rates = { path = "../interledger-rates", version = "1.0.0", optional = true, default-features = false }
-interledger-router = { path = "../interledger-router", version = "1.0.0", optional = true, default-features = false }
-interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
-interledger-service-util = { path = "../interledger-service-util", version = "1.0.0", optional = true, default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "1.0.0", optional = true, default-features = false }
-interledger-spsp = { path = "../interledger-spsp", version = "1.0.0", optional = true, default-features = false }
-interledger-stream = { path = "../interledger-stream", version = "1.0.0", optional = true, default-features = false }
-interledger-store = { path = "../interledger-store", version = "1.0.0", optional = true, default-features = false, features = ["redis"] }
+interledger-api = { path = "../interledger-api", version = "^0.3.0", optional = true, default-features = false }
+interledger-btp = { path = "../interledger-btp", version = "^0.4.0", optional = true, default-features = false }
+interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", optional = true, default-features = false }
+interledger-http = { path = "../interledger-http", version = "^0.4.0", optional = true, default-features = false }
+interledger-ildcp = { path = "../interledger-ildcp", version = "^0.4.0", optional = true, default-features = false }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
+interledger-rates = { path = "../interledger-rates", version = "^0.4.0", optional = true, default-features = false }
+interledger-router = { path = "../interledger-router", version = "^0.4.0", optional = true, default-features = false }
+interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
+interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", optional = true, default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", optional = true, default-features = false }
+interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
+interledger-stream = { path = "../interledger-stream", version = "^0.4.0", optional = true, default-features = false }
+interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -54,7 +54,7 @@ interledger-service-util = { path = "../interledger-service-util", version = "^0
 interledger-settlement = { path = "../interledger-settlement", version = "^0.4.0", optional = true, default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.5.0", optional = true, default-features = false }
-interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }
+interledger-store = { path = "../interledger-store", version = "^0.5.0", optional = true, default-features = false, features = ["redis"] }
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -51,7 +51,7 @@ interledger-rates = { path = "../interledger-rates", version = "^0.4.0", optiona
 interledger-router = { path = "../interledger-router", version = "^0.4.0", optional = true, default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", optional = true, default-features = false }
-interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", optional = true, default-features = false }
+interledger-settlement = { path = "../interledger-settlement", version = "^0.4.0", optional = true, default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.5.0", optional = true, default-features = false }
 interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interledger"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Evan Schwartz <evan@ripple.com>"]
 description = "Interledger client library"
 license = "Apache-2.0"


### PR DESCRIPTION
CC: #668, #557

This first reverts the commit which bumped the versions to 1.0.0, then bumps the minor versions for the crates we know have in the past identified have received breaking changes.

If you go through the invidiual commits you can see how much churn a single version bump causes. Given how the `interledger` crate depends on all public api across crates, it does make me think if it would be best for this codebase to just have non-crates.io softer releases as the current dependency jungle is quite thick, with the re-exports the breakage will be difficult to track.

There's no hurry on my part, but this puts in code what I've been thinking recently and commenting on the issues.